### PR TITLE
prevent gevent patch from being applied unnecessarily

### DIFF
--- a/pillowtop/run_pillowtop.py
+++ b/pillowtop/run_pillowtop.py
@@ -1,39 +1,7 @@
 from gevent import monkey; monkey.patch_all()
 from gevent.pool import Pool
 from restkit.session import set_session; set_session("gevent")
-
-
-class PillowtopConfigurationException(Exception):
-    pass
-
-
-def import_settings():
-    try:
-        from django.conf import settings
-    except Exception, ex:
-        #if we are not in a django context, then import local pillowsettings
-        print "django import"
-        print ex
-        import pillowsettings as settings
-    return settings
-
-
-def import_pillows(instantiate=True):
-    settings = import_settings()
-
-    pillowtops = []
-    if hasattr(settings, 'PILLOWTOPS'):
-        for full_str in settings.PILLOWTOPS:
-            comps = full_str.split('.')
-            pillowtop_class_str = comps[-1]
-            mod_str = '.'.join(comps[0:-1])
-            mod = __import__(mod_str, {},{},[pillowtop_class_str])
-            if hasattr(mod, pillowtop_class_str):
-                pillowtop_class  = getattr(mod, pillowtop_class_str)
-                pillowtops.append(pillowtop_class() if instantiate else pillowtop_class)
-            else:
-                raise PillowtopConfigurationException("Error, the pillow class %s could not be imported" % full_str)
-    return pillowtops
+from pillowtop.utils import import_pillows
 
 
 #standalone pillowtop runner

--- a/pillowtop/tests.py
+++ b/pillowtop/tests.py
@@ -1,6 +1,6 @@
 from unittest2 import TestCase
 from pillowtop.listener import BasicPillow
-from pillowtop.run_pillowtop import import_pillows
+from pillowtop.utils import import_pillows
 from inspect import isclass
 
 
@@ -15,7 +15,7 @@ class PillowTopTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         import pillowtop.run_pillowtop
-        pillowtop.run_pillowtop.import_settings = import_settings
+        pillowtop.utils.import_settings = import_settings
 
     def test_import_pillows_class_only(self):
         pillows = import_pillows(instantiate=False)

--- a/pillowtop/utils.py
+++ b/pillowtop/utils.py
@@ -1,0 +1,31 @@
+class PillowtopConfigurationException(Exception):
+    pass
+
+
+def import_settings():
+    try:
+        from django.conf import settings
+    except Exception, ex:
+        #if we are not in a django context, then import local pillowsettings
+        print "django import"
+        print ex
+        import pillowsettings as settings
+    return settings
+
+
+def import_pillows(instantiate=True):
+    settings = import_settings()
+
+    pillowtops = []
+    if hasattr(settings, 'PILLOWTOPS'):
+        for full_str in settings.PILLOWTOPS:
+            comps = full_str.split('.')
+            pillowtop_class_str = comps[-1]
+            mod_str = '.'.join(comps[0:-1])
+            mod = __import__(mod_str, {},{},[pillowtop_class_str])
+            if hasattr(mod, pillowtop_class_str):
+                pillowtop_class  = getattr(mod, pillowtop_class_str)
+                pillowtops.append(pillowtop_class() if instantiate else pillowtop_class)
+            else:
+                raise PillowtopConfigurationException("Error, the pillow class %s could not be imported" % full_str)
+    return pillowtops


### PR DESCRIPTION
Prevent this error when running pydev in muliproc mode:

Exception in thread pydevd.CheckAliveThread:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 551, in __bootstrap_inner
    self.run()
  File "/home/simon/dev/pycharm-2.7.2/helpers/pydev/pydevd_comm.py", line 252, in run
    self.OnRun()
  File "/home/simon/dev/pycharm-2.7.2/helpers/pydev/pydevd.py", line 181, in OnRun
    time.sleep(0.3)
  File "/home/simon/.virtualenvs/commcarehq/local/lib/python2.7/site-packages/gevent/hub.py", line 79, in sleep
    switch_result = get_hub().switch()
  File "/home/simon/.virtualenvs/commcarehq/local/lib/python2.7/site-packages/gevent/hub.py", line 135, in get_hub
    raise NotImplementedError('gevent is only usable from a single thread')
NotImplementedError: gevent is only usable from a single thread
