### PR TITLE
rename pillowtop.utils.import_pillows to pillowtop.get_all_pillows

### DIFF
--- a/pillowtop/__init__.py
+++ b/pillowtop/__init__.py
@@ -1,0 +1,1 @@
+from pillowtop.utils import get_all_pillows

--- a/pillowtop/management/commands/ptop_es_manage.py
+++ b/pillowtop/management/commands/ptop_es_manage.py
@@ -5,7 +5,7 @@ import simplejson
 from corehq.elastic import get_es
 from pillowtop.listener import AliasedElasticPillow
 from pillowtop.management.pillowstate import get_pillow_states
-from pillowtop.run_pillowtop import import_pillows
+from pillowtop import get_all_pillows
 
 
 class Command(LabelCommand):
@@ -45,7 +45,7 @@ class Command(LabelCommand):
         flip_single = options['pillow_class']
         es = get_es()
 
-        pillows = import_pillows()
+        pillows = get_all_pillows()
         aliased_pillows = filter(lambda x: isinstance(x, AliasedElasticPillow), pillows)
 
         if show_info:

--- a/pillowtop/management/commands/ptop_reset_checkpoint.py
+++ b/pillowtop/management/commands/ptop_reset_checkpoint.py
@@ -1,8 +1,8 @@
 from optparse import make_option
-from django.core.management.base import NoArgsCommand, LabelCommand
+from django.core.management.base import LabelCommand
 import sys
-from pillowtop.run_pillowtop import import_pillows
-from django.conf import settings
+from pillowtop import get_all_pillows
+
 
 class Command(LabelCommand):
     help = "Reset checkpoints for pillowtop"
@@ -22,7 +22,7 @@ class Command(LabelCommand):
         """
         More targeted pillow checkpoint reset system - must specify the pillow class_name to reset the checkpoint
         """
-        all_pillows = import_pillows()
+        all_pillows = get_all_pillows()
 
         pillow_class_names = [x.__class__.__name__ for x in all_pillows]
 

--- a/pillowtop/run_pillowtop.py
+++ b/pillowtop/run_pillowtop.py
@@ -1,13 +1,13 @@
 from gevent.pool import Pool
 from restkit.session import set_session; set_session("gevent")
-from pillowtop.utils import import_pillows
+from pillowtop import get_all_pillows
 
 
 #standalone pillowtop runner
 def start_pillows():
     #gevent patching: logging doesn't seem to work unless thread is not patched
 
-    pillows = import_pillows()
+    pillows = get_all_pillows()
     pool = Pool(len(pillows))
     while True:
         for p in pillows:

--- a/pillowtop/tests.py
+++ b/pillowtop/tests.py
@@ -1,6 +1,6 @@
 from unittest2 import TestCase
+from pillowtop import get_all_pillows
 from pillowtop.listener import BasicPillow
-from pillowtop.utils import import_pillows
 from inspect import isclass
 
 
@@ -18,12 +18,12 @@ class PillowTopTestCase(TestCase):
         pillowtop.utils.import_settings = import_settings
 
     def test_import_pillows_class_only(self):
-        pillows = import_pillows(instantiate=False)
+        pillows = get_all_pillows(instantiate=False)
         self.assertEquals(len(pillows), 1)
         self.assertTrue(isclass(pillows[0]))
 
     def test_import_pillows(self):
-        pillows = import_pillows(instantiate=True)
+        pillows = get_all_pillows(instantiate=True)
         self.assertEquals(len(pillows), 1)
         self.assertFalse(isclass(pillows[0]))
 

--- a/pillowtop/utils.py
+++ b/pillowtop/utils.py
@@ -1,3 +1,6 @@
+import warnings
+
+
 class PillowtopConfigurationException(Exception):
     pass
 
@@ -14,6 +17,13 @@ def import_settings():
 
 
 def import_pillows(instantiate=True):
+    warnings.warn('pillowtop.utils.import_pillows deprecated, '
+                  'please use pillowtop.get_all_pillows instead.',
+                  DeprecationWarning)
+    return get_all_pillows(instantiate=instantiate)
+
+
+def get_all_pillows(instantiate=True):
     settings = import_settings()
 
     pillowtops = []
@@ -22,10 +32,14 @@ def import_pillows(instantiate=True):
             comps = full_str.split('.')
             pillowtop_class_str = comps[-1]
             mod_str = '.'.join(comps[0:-1])
-            mod = __import__(mod_str, {},{},[pillowtop_class_str])
+            mod = __import__(mod_str, {}, {}, [pillowtop_class_str])
             if hasattr(mod, pillowtop_class_str):
-                pillowtop_class  = getattr(mod, pillowtop_class_str)
-                pillowtops.append(pillowtop_class() if instantiate else pillowtop_class)
+                pillowtop_class = getattr(mod, pillowtop_class_str)
+                pillowtops.append(pillowtop_class() if instantiate
+                                  else pillowtop_class)
             else:
-                raise PillowtopConfigurationException("Error, the pillow class %s could not be imported" % full_str)
+                raise PillowtopConfigurationException(
+                    ("Error, the pillow class %s "
+                     "could not be imported") % full_str
+                )
     return pillowtops


### PR DESCRIPTION
I'm trying to start thinking about designing APIs with how they're used from the outside in mind, instead of how they're implemented. Was using this for something else, and `from pillowtop.utils import import_pillows` sounds like this scary private thing, whereas `from pillowtop import get_all_pillows` is where I'd look if what I wanted to do was get all the pillows that pillowtop knows about.
