### PR TITLE
restart processing after checkpoint reset

### DIFF
--- a/pillowtop/listener.py
+++ b/pillowtop/listener.py
@@ -164,6 +164,9 @@ class BasicPillow(object):
                 self.changes_seen = 0
 
     def _parse_change(self, line):
+        """
+        Copied from CouchDBKit ChangesStream class
+        """
         if line.startswith('{"results":') or line.startswith('"last_seq'):
             return None
         else:


### PR DESCRIPTION
Also keep checkpoint updated using heartbeat even if no changes are being streamed.
