### PR TITLE
Fix bug in change streamer

### DIFF
--- a/pillowtop/listener.py
+++ b/pillowtop/listener.py
@@ -149,7 +149,7 @@ class BasicPillow(object):
             query_params.update({
                 'since': self.since,
                 'filter': self.couch_filter,
-                'include_docs': self.include_docs,
+                'include_docs': str(self.include_docs).lower(),
             })
             query_params.update(self.extra_args)
             try:


### PR DESCRIPTION
Tested on local instance of couch. include_docs parameter values “True” and “False” apparently both evaluate to false since neither value causes the docs to be included. A value of “true” causes them to be included.

http://127.0.0.1:5984/commcarehq/_changes?include_docs=True - not included
http://127.0.0.1:5984/commcarehq/_changes?include_docs=true - included

@czue @snopoke 
