### PR TITLE
new release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pillowtop',
-    version='0.1.5',
+    version='0.1.6',
     description='A couchdbkit changes listener for doing backend processing',
     author='Dimagi',
     author_email='dev@dimagi.com',


### PR DESCRIPTION
django 1.7 breaks couchdbkit. this release pins the requirements to pre 1.7
