### PR TITLE
don't crash on null doc_dates in pillow retry

### DIFF
--- a/pillow_retry/models.py
+++ b/pillow_retry/models.py
@@ -83,7 +83,8 @@ class PillowError(models.Model):
             )
 
             if change_meta:
-                date = parse(change_meta.get('date'))
+                date_string = change_meta.get('date')
+                date = parse(date_string) if date_string is not None else None
                 domains = ','.join(change_meta.get('domains'))
                 error.domains = (domains[:252] + '...') if len(domains) > 255 else domains
                 error.doc_type = change_meta.get('doc_type')

--- a/pillow_retry/tests.py
+++ b/pillow_retry/tests.py
@@ -80,6 +80,16 @@ class PillowRetryTestCase(TestCase):
         self.assertEqual(get.doc_date, parse(date))
         get.save()
 
+    def test_null_meta_date(self):
+        id = '12335'
+        meta = {
+            'domains': ['a' * 247, '123456789'],
+            'doc_type': 'something',
+            'date': None,
+        }
+        get = PillowError.get_or_create({'id': id}, FakePillow(), meta)
+        self.assertEqual(None, get.doc_date)
+
     def test_get_errors_to_process(self):
         # Only re-process errors with
         # current_attempt < setting.PILLOW_RETRY_QUEUE_MAX_PROCESSING_ATTEMPTS


### PR DESCRIPTION
related to http://manage.dimagi.com/default.asp?149488
