### PR TITLE
fix pillow retry change serialization issue

### DIFF
--- a/pillow_retry/models.py
+++ b/pillow_retry/models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 import math
 from django.db import models
 from django.db.models.aggregates import Count
-from pillowtop.feed.couch import change_from_couch_row
+from pillowtop.feed.couch import change_from_couch_row, force_to_change
 
 ERROR_MESSAGE_LENGTH = 512
 
@@ -75,9 +75,9 @@ class PillowError(models.Model):
     @classmethod
     def get_or_create(cls, change, pillow, change_meta=None):
         pillow_path = path_from_object(pillow)
-
-        change.get('doc', None)
-        doc_id = change['id']
+        change = force_to_change(change)
+        change.document
+        doc_id = change.id
         try:
             error = cls.objects.get(doc_id=doc_id, pillow=pillow_path)
         except cls.DoesNotExist:
@@ -88,7 +88,7 @@ class PillowError(models.Model):
                 date_created=now,
                 date_last_attempt=now,
                 date_next_attempt=now,
-                change=json.dumps(change)
+                change=json.dumps(change.to_dict())
             )
 
             if change_meta:

--- a/pillow_retry/models.py
+++ b/pillow_retry/models.py
@@ -6,6 +6,7 @@ from django.conf import settings
 import math
 from django.db import models
 from django.db.models.aggregates import Count
+from pillowtop.feed.couch import change_from_couch_row
 
 ERROR_MESSAGE_LENGTH = 512
 
@@ -41,7 +42,7 @@ class PillowError(models.Model):
 
     @property
     def change_dict(self):
-        return json.loads(self.change) if self.change else {'id': self.doc_id}
+        return change_from_couch_row(json.loads(self.change) if self.change else {'id': self.doc_id})
 
     class Meta:
         app_label = 'pillow_retry'

--- a/pillow_retry/models.py
+++ b/pillow_retry/models.py
@@ -41,7 +41,7 @@ class PillowError(models.Model):
     queued = models.BooleanField(default=False)
 
     @property
-    def change_dict(self):
+    def change_object(self):
         return change_from_couch_row(json.loads(self.change) if self.change else {'id': self.doc_id})
 
     class Meta:

--- a/pillow_retry/tasks.py
+++ b/pillow_retry/tasks.py
@@ -49,7 +49,7 @@ def process_pillow_retry(error_doc_id):
                 release_lock(lock, True)
                 return
 
-        change = error_doc.change_dict
+        change = error_doc.change_object
         if pillow.include_docs:
             try:
                 change.document = pillow.couch_db.open_doc(change.id)

--- a/pillow_retry/tasks.py
+++ b/pillow_retry/tasks.py
@@ -52,9 +52,9 @@ def process_pillow_retry(error_doc_id):
         change = error_doc.change_dict
         if pillow.include_docs:
             try:
-                change['doc'] = pillow.couch_db.open_doc(change['id'])
+                change.document = pillow.couch_db.open_doc(change.id)
             except ResourceNotFound:
-                change['deleted'] = True
+                change.deleted = True
 
         try:
             try:

--- a/pillow_retry/tests.py
+++ b/pillow_retry/tests.py
@@ -36,8 +36,8 @@ class PillowRetryTestCase(TestCase):
         error = create_error(change_dict)
         self.assertEqual(error.doc_id, id)
         self.assertEqual(error.pillow, 'pillow_retry.tests.FakePillow')
-        self.assertEqual(error.change_dict.id, id)
-        self.assertEqual(error.change_dict.sequence_id, 54321)
+        self.assertEqual(error.change_object.id, id)
+        self.assertEqual(error.change_object.sequence_id, 54321)
 
     def test_attempts(self):
         message = 'ex message'

--- a/pillow_retry/tests.py
+++ b/pillow_retry/tests.py
@@ -6,6 +6,8 @@ from pillow_retry.models import PillowError, Stub
 from django.test import TestCase
 from pillow_retry.tasks import process_pillow_retry
 from pillowtop.couchdb import CachedCouchDB
+from pillowtop.feed.couch import change_from_couch_row
+from pillowtop.feed.interface import Change
 from pillowtop.listener import BasicPillow
 
 
@@ -18,6 +20,8 @@ def get_ex_tb(message, ex_class=None):
 
 
 def create_error(change, message='message', attempts=0, pillow=None, ex_class=None):
+    if not isinstance(change, Change):
+        change = change_from_couch_row(change)
     error = PillowError.get_or_create(change, pillow or FakePillow())
     for n in range(0, attempts):
         error.add_attempt(*get_ex_tb(message, ex_class=ex_class))

--- a/pillowtop/feed/couch.py
+++ b/pillowtop/feed/couch.py
@@ -29,7 +29,7 @@ class CouchChangeFeed(ChangeFeed):
 def change_from_couch_row(couch_change):
     return Change(
         id=couch_change['id'],
-        sequence_id=couch_change['seq'],
+        sequence_id=couch_change.get('seq', None),
         document=couch_change.get('doc', None),
         deleted=couch_change.get('deleted', False),
     )

--- a/pillowtop/feed/couch.py
+++ b/pillowtop/feed/couch.py
@@ -1,4 +1,5 @@
 from couchdbkit import ChangesStream
+from django.conf import settings
 from pillowtop.feed.interface import ChangeFeed, Change
 
 
@@ -32,3 +33,14 @@ def change_from_couch_row(couch_change):
         document=couch_change.get('doc', None),
         deleted=couch_change.get('deleted', False),
     )
+
+
+def force_to_change(dict_or_change):
+    if not isinstance(dict_or_change, Change):
+        if not settings.UNIT_TESTING:
+            from corehq.util.soft_assert import soft_assert
+            _assert = soft_assert(to=['czue' + '@' + 'dimagi.com'], exponential_backoff=True)
+            _assert(False, u"Change wasn't a Change object!", dict_or_change)
+        assert isinstance(dict_or_change, dict)
+        return change_from_couch_row(dict_or_change)
+    return dict_or_change

--- a/pillowtop/feed/interface.py
+++ b/pillowtop/feed/interface.py
@@ -41,6 +41,9 @@ class Change(object):
     def pop(self, key, default):
         raise NotImplemented('This is a read-only dictionary!')
 
+    def to_dict(self):
+        return self._dict
+
 
 class ChangeFeed(object):
     """

--- a/pillowtop/feed/interface.py
+++ b/pillowtop/feed/interface.py
@@ -5,7 +5,15 @@ class Change(object):
     """
     A record of a change. Provides a dict-like interface for backwards compatibility with couch changes.
     """
+    PROPERTY_DICT_MAP = {
+        'id': 'id',
+        'sequence_id': 'seq',
+        'document': 'doc',
+        'deleted': 'deleted'
+    }
+
     def __init__(self, id, sequence_id, document=None, deleted=False):
+        self._dict = {}
         self.id = id
         self.sequence_id = sequence_id
         self.document = document
@@ -19,6 +27,11 @@ class Change(object):
 
     def __len__(self):
         return len(self._dict)
+
+    def __setattr__(self, name, value):
+        super(Change, self).__setattr__(name, value)
+        if name in self.PROPERTY_DICT_MAP:
+            self._dict[self.PROPERTY_DICT_MAP[name]] = value
 
     def __getitem__(self, key):
         return self._dict[key]
@@ -35,7 +48,7 @@ class Change(object):
     def __contains__(self, item):
         return item in self._dict
 
-    def get(self, key, default):
+    def get(self, key, default=None):
         return self._dict.get(key, default)
 
     def pop(self, key, default):

--- a/pillowtop/tests/test_changes.py
+++ b/pillowtop/tests/test_changes.py
@@ -1,5 +1,6 @@
 from django.test import SimpleTestCase
-from pillowtop.feed.couch import change_from_couch_row
+from pillowtop.feed.couch import change_from_couch_row, force_to_change
+from pillowtop.feed.interface import Change
 
 
 class TestCouchChange(SimpleTestCase):
@@ -11,10 +12,16 @@ class TestCouchChange(SimpleTestCase):
             'seq': '21',
             'deleted': False
         }
-        change = change_from_couch_row(couch_row)
-        self.assertEqual('an-id', change.id)
-        self.assertEqual(couch_row['doc'], change.document)
-        self.assertEqual('21', change.sequence_id)
-        self.assertEqual(False, change.deleted)
-        for key in couch_row:
-            self.assertEqual(couch_row[key], change[key])
+        ways_to_make_change_object = [
+            change_from_couch_row(couch_row),
+            force_to_change(couch_row),
+            force_to_change(force_to_change(couch_row)),  # tests passing an already converted object
+        ]
+        for change in ways_to_make_change_object:
+            self.assertTrue(isinstance(change, Change))
+            self.assertEqual('an-id', change.id)
+            self.assertEqual(couch_row['doc'], change.document)
+            self.assertEqual('21', change.sequence_id)
+            self.assertEqual(False, change.deleted)
+            for key in couch_row:
+                self.assertEqual(couch_row[key], change[key])

--- a/pillowtop/tests/test_changes.py
+++ b/pillowtop/tests/test_changes.py
@@ -25,3 +25,32 @@ class TestCouchChange(SimpleTestCase):
             self.assertEqual(False, change.deleted)
             for key in couch_row:
                 self.assertEqual(couch_row[key], change[key])
+
+    def test_set_attr_id(self):
+        change = Change(id='first-id', sequence_id='')
+        self.assertEqual('first-id', change.id)
+        change.id = 'new-id'
+        self.assertEqual('new-id', change.id)
+        self.assertEqual('new-id', change.to_dict()['id'])
+
+    def test_set_attr_document(self):
+        change = Change(id='id', sequence_id='', document={})
+        self.assertEqual({}, change.document)
+        document = {'foo': 'bar'}
+        change.document = document
+        self.assertEqual(document, change.document)
+        self.assertEqual(document, change.to_dict()['doc'])
+
+    def test_set_attr_seq(self):
+        change = Change(id='id', sequence_id='seq')
+        self.assertEqual('seq', change.sequence_id)
+        change.sequence_id = 'seq-2'
+        self.assertEqual('seq-2', change.sequence_id)
+        self.assertEqual('seq-2', change.to_dict()['seq'])
+
+    def test_set_attr_deleted(self):
+        change = Change(id='id', sequence_id='', deleted=True)
+        self.assertTrue(change.deleted)
+        change.deleted = False
+        self.assertFalse(change.deleted)
+        self.assertFalse(change.to_dict()['deleted'])

--- a/settings.py
+++ b/settings.py
@@ -86,9 +86,17 @@ LOGGING = {
 }
 
 try:
+    import sys
+    UNIT_TESTING = 'test' == sys.argv[1]
+except IndexError:
+    UNIT_TESTING = False
+
+
+try:
     from localsettings import *
 except ImportError:
     pass
+
 
 
 COUCHDB_DATABASES = [ (app, COUCH_DATABASE) for app in [


### PR DESCRIPTION
also forces retry to work exclisively with `Change` objects.

http://manage.dimagi.com/default.asp?183555

can be read commit by commit

@dannyroberts 