### PR TITLE
Checkpoint refactors

### DIFF
--- a/pillowtop/checkpoints/manager.py
+++ b/pillowtop/checkpoints/manager.py
@@ -4,6 +4,7 @@ import pytz
 from pillowtop.checkpoints.util import get_formatted_current_timestamp
 from pillowtop.dao.exceptions import DocumentNotFoundError
 from pillowtop.exceptions import PillowtopCheckpointReset
+from pillowtop.logger import pillow_logging
 
 
 class PillowCheckpointManager(object):
@@ -48,6 +49,9 @@ class PillowCheckpoint(object):
         return checkpoint
 
     def update_to(self, seq):
+        pillow_logging.info(
+            "(%s) setting checkpoint: %s" % (self.checkpoint_id, seq)
+        )
         checkpoint = self.get_or_create(verify_unchanged=True)
         checkpoint['seq'] = seq
         checkpoint['timestamp'] = get_formatted_current_timestamp()

--- a/pillowtop/listener.py
+++ b/pillowtop/listener.py
@@ -151,10 +151,11 @@ class BasicPillow(PillowBase):
         Parent processsor for a pillow class - this should not be overridden.
         This workflow is made for the situation where 1 change yields 1 transport/transaction
         """
+        self.process_change(change)
+
+    def fire_change_processed_event(self, change, context):
         if context.changes_seen % self.checkpoint_frequency == 0 and context.do_set_checkpoint:
             self.set_checkpoint(change)
-
-        self.process_change(change)
 
     def process_change(self, change, is_retry_attempt=False):
         try:

--- a/pillowtop/pillow/interface.py
+++ b/pillowtop/pillow/interface.py
@@ -15,18 +15,6 @@ class PillowRuntimeContext(object):
         self.do_set_checkpoint = do_set_checkpoint
 
 
-class ChangeEventHandler(object):
-    """
-    Runtime context for a pillow. Gets passed around during the processing methods
-    so that other functions can use it without maintaining global state on the class.
-    """
-    __metaclass__ = ABCMeta
-
-    @abstractmethod
-    def fire_change_processed(self, change, context):
-        pass
-
-
 class PillowBase(object):
     """
     This defines the external pillowtop API. Everything else should be considered a specialization
@@ -107,6 +95,17 @@ class PillowBase(object):
 
     @abstractmethod
     def fire_change_processed_event(self, change, context):
+        pass
+
+
+class ChangeEventHandler(object):
+    """
+    A change-event-handler object used in constructed pillows.
+    """
+    __metaclass__ = ABCMeta
+
+    @abstractmethod
+    def fire_change_processed(self, change, context):
         pass
 
 

--- a/pillowtop/pillow/interface.py
+++ b/pillowtop/pillow/interface.py
@@ -66,9 +66,6 @@ class PillowBase(object):
         return self.checkpoint.get_or_create(verify_unchanged=verify_unchanged)
 
     def set_checkpoint(self, change):
-        pillow_logging.info(
-            "(%s) setting checkpoint: %s" % (self.checkpoint.checkpoint_id, change['seq'])
-        )
         self.checkpoint.update_to(change['seq'])
 
     def reset_checkpoint(self):

--- a/pillowtop/tests/test_elasticsearch.py
+++ b/pillowtop/tests/test_elasticsearch.py
@@ -2,6 +2,7 @@ import uuid
 from django.test import SimpleTestCase
 from pillowtop.feed.interface import Change
 from pillowtop.listener import AliasedElasticPillow
+from pillowtop.pillow.interface import PillowRuntimeContext
 from .utils import require_explicit_elasticsearch_testing, get_doc_count
 
 
@@ -90,7 +91,7 @@ class ElasticPillowTest(SimpleTestCase):
             sequence_id=0,
             document=doc
         )
-        pillow.processor(change, False)
+        pillow.processor(change, PillowRuntimeContext(do_set_checkpoint=False))
         self.assertEqual(1, get_doc_count(self.es, self.index))
         es_doc = self.es.get_source(self.index, doc_id)
         for prop in doc:


### PR DESCRIPTION
can be read commit-by-commit. codependent with https://github.com/dimagi/commcare-hq/pull/8892

I think this is pretty safe, though open to push-back that I should put on staging for a bit. Have tested the different pillow-types locally