### PR TITLE
don't fail hard when passing an empty set of changes to send_bulk

### DIFF
--- a/pillowtop/listener.py
+++ b/pillowtop/listener.py
@@ -613,6 +613,8 @@ class AliasedElasticPillow(BasicPillow):
             return None
 
     def process_bulk(self, changes):
+        if not changes:
+            return
         self.allow_updates = False
         self.bulk = True
         bstart = datetime.utcnow()

--- a/pillowtop/tests/test_elasticsearch.py
+++ b/pillowtop/tests/test_elasticsearch.py
@@ -117,3 +117,9 @@ class ElasticPillowTest(SimpleTestCase):
             es_doc = self.es.get_source(self.index, doc['_id'])
             for prop in doc.keys():
                 self.assertEqual(doc[prop], es_doc[prop])
+
+    def test_send_bulk_empty(self):
+        pillow = TestElasticPillow()
+        # this used to fail hard before this test was added
+        pillow.process_bulk([])
+        self.assertEqual(0, get_doc_count(self.es, self.index))


### PR DESCRIPTION
@snopoke @emord @esoergel this was the root cause of the reindexing issue