### PR TITLE
Support creating new indices with rawes upgrade

### DIFF
--- a/pillowtop/listener.py
+++ b/pillowtop/listener.py
@@ -465,15 +465,19 @@ class AliasedElasticPillow(BasicPillow):
         """
         Initializes the elasticsearch mapping for this pillow if it is not found.
         """
-        mapping = self.get_index_mapping()
-        if not mapping:
+        try:
+            mapping = self.get_index_mapping()
+        except ElasticException:
             pillow_logging.info("Initializing elasticsearch mapping for [%s]" % self.es_type)
             mapping = copy(self.default_mapping)
             mapping['_meta']['created'] = datetime.isoformat(datetime.utcnow())
-            mapping_res = self.set_mapping(self.es_type, {self.es_type: mapping})
-            if mapping_res.get('ok', False) and mapping_res.get('acknowledged', False):
-                # API confirms OK, trust it.
-                pillow_logging.info("Mapping set: [%s] %s" % (self.es_type, mapping_res))
+            try:
+                mapping_res = self.set_mapping(self.es_type, {self.es_type: mapping})
+                if mapping_res.get('ok', False) and mapping_res.get('acknowledged', False):
+                    # API confirms OK, trust it.
+                    pillow_logging.info("Mapping set: [%s] %s" % (self.es_type, mapping_res))
+            except ElasticException:
+                pass
         else:
             pillow_logging.info("Elasticsearch mapping for [%s] was already present." % self.es_type)
 

--- a/pillowtop/listener.py
+++ b/pillowtop/listener.py
@@ -461,7 +461,7 @@ class AliasedElasticPillow(BasicPillow):
         else:
             pillow_logging.info("Pillowtop [%s] Started with no mapping from server in memory testing mode" % self.get_name())
 
-    def _mapping_exists(self):
+    def mapping_exists(self):
         try:
             return bool(self.get_index_mapping())
         except ElasticException:
@@ -471,7 +471,7 @@ class AliasedElasticPillow(BasicPillow):
         """
         Initializes the elasticsearch mapping for this pillow if it is not found.
         """
-        if not self._mapping_exists():
+        if not self.mapping_exists():
             pillow_logging.info("Initializing elasticsearch mapping for [%s]" % self.es_type)
             mapping = copy(self.default_mapping)
             mapping['_meta']['created'] = datetime.isoformat(datetime.utcnow())

--- a/pillowtop/listener.py
+++ b/pillowtop/listener.py
@@ -455,7 +455,7 @@ class AliasedElasticPillow(BasicPillow):
         index_exists = self.index_exists()
         if create_index and not index_exists:
             self.create_index()
-        if self.online:
+        if self.online and (index_exists or create_index):
             pillow_logging.info("Pillowtop [%s] Initializing mapping in ES" % self.get_name())
             self.initialize_mapping_if_necessary()
         else:

--- a/pillowtop/tests/test_elasticsearch.py
+++ b/pillowtop/tests/test_elasticsearch.py
@@ -57,6 +57,12 @@ class ElasticPillowTest(SimpleTestCase):
             mapping['properties']['doc_type']['index']
         )
 
+    def test_create_index_false_online_true(self):
+        # this test use to raise a hard error so doesn't actually test anything
+        pillow = TestElasticPillow(create_index=False)
+        self.assertFalse(pillow.index_exists())
+        self.assertFalse(pillow.mapping_exists())
+
     def test_refresh_index(self):
         pillow = TestElasticPillow()
         doc_id = uuid.uuid4().hex


### PR DESCRIPTION
Previously, `get_index_mapping` would return `None`, now it fails hard.  Also, in `ptop_preindex`, we initialize the pillows with `create_index=False`, but this still attempted to create a mapping if the index didn't exist.
I'm seeing the preindex hang at the end, but I think that's unrelated, and I'll fix/PR separately.
@czue @emord 

edit: I opened a [ticket](http://manage.dimagi.com/default.asp?186992) for that error I mentioned